### PR TITLE
Float64 typing to speed up simulation x35

### DIFF
--- a/perf/Microgrids.jl_performance_analysis.ipynb
+++ b/perf/Microgrids.jl_performance_analysis.ipynb
@@ -1,0 +1,565 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "993d7bab-bd63-4848-a149-1bc5502a1216",
+   "metadata": {},
+   "source": [
+    "# Performance analysis of Microgrids.jl\n",
+    "\n",
+    "e.g. timing, profiling and typing issues\n",
+    "\n",
+    "Run on Dell notebook with Intel Core i7-1165G7 @ 2.80GHz, *powered by the dock*\n",
+    "\n",
+    "PH, June 2022"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "91688f98-2f64-4936-a7e2-aa8ae544ebd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Microgrids\n",
+    "using BenchmarkTools\n",
+    "using CSV, DataFrames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "05944285-4478-4523-868c-29539cc8c2ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "load_ts"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\"load time series from CSV file\"\"\"\n",
+    "function load_ts()\n",
+    "    data = DataFrame(CSV.File(\"$(@__DIR__)/../examples/microgrid_with_PV_BT_DG/data/Ouessant_data_2016.csv\"))\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcba5928-3113-443b-933f-1ebf705d106d",
+   "metadata": {},
+   "source": [
+    "## Microgrid data preparation\n",
+    "\n",
+    "* **1.9 ms** to load CSV time series for 1 year\n",
+    "* otherwise, creating the `Microgrid` structure with all its components (`Photovoltaic`...) is negligible: 15 µs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08a81513-03e1-4af4-838b-4f4fc02605bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function J(x, args)\n",
+    "end\n",
+    "\n",
+    "for i \n",
+    "    \n",
+    "    f(x, grad) = J(x,r[i])\n",
+    "    optimize(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6ba8de07-86cf-43f1-acb4-b00ab26a4355",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1.894 ms (398 allocations: 1.23 MiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@btime load_ts();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "916c7f55-5ed7-4518-bda3-3920339c1f6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const my_data = load_ts();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "efff55db-2838-4ce6-9314-26b0f1a99d2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "mg_create (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function mg_create(data)\n",
+    "    # Simulation steps\n",
+    "    ntimestep = length(data.Load)\n",
+    "\n",
+    "    # Components parameters\n",
+    "    # Project\n",
+    "    lifetime = 25\n",
+    "    discount_rate = 0.05\n",
+    "    timestep = 1\n",
+    "    # Load\n",
+    "    Pload = data.\"Load\"[1:ntimestep]\n",
+    "    # Photovoltaic\n",
+    "    power_rated_PV = 4106.82251423571\n",
+    "    fPV = 1.\n",
+    "    IT = data.\"Ppv1k\"[1:ntimestep] ./ 1000\n",
+    "    IS = ones(ntimestep)\n",
+    "    investiment_cost_PV = 1200.\n",
+    "    om_cost_PV = 20.  \n",
+    "    replacement_cost_PV = 1200.\n",
+    "    salvage_cost_PV = 1200.\n",
+    "    lifetime_PV = 25\n",
+    "    # Battery\n",
+    "    energy_initial = 0.\n",
+    "    energy_max = 6839.87944197573\n",
+    "    energy_min = 0\n",
+    "    power_min = -1.114*energy_max\n",
+    "    power_max = 1.002*energy_max\n",
+    "    loss = 0.05\n",
+    "    investiment_cost_BT = 350.\n",
+    "    om_cost_BT = 10.\n",
+    "    replacement_cost_BT = 350.\n",
+    "    salvage_cost_BT = 350.\n",
+    "    lifetime_BT = 15\n",
+    "    lifetime_thrpt = 3000\n",
+    "    # Diesel generator\n",
+    "    power_rated_DG = 1800.\n",
+    "    min_load_ratio = 0\n",
+    "    F0 = 0.0\n",
+    "    F1 = 0.240\n",
+    "    fuel_cost = 1.\n",
+    "    investiment_cost_DG = 400.\n",
+    "    om_cost_DG = 0.02\n",
+    "    replacement_cost_DG = 400.\n",
+    "    salvage_cost_DG = 400.\n",
+    "    lifetime_DG = 15000\n",
+    "\n",
+    "    # Create microgrid components\n",
+    "    project = Project(lifetime, discount_rate, timestep)\n",
+    "    dieselgenerator = DieselGenerator(power_rated_DG, min_load_ratio, F0, F1, fuel_cost, investiment_cost_DG, om_cost_DG, replacement_cost_DG, salvage_cost_DG, lifetime_DG)\n",
+    "    photovoltaic = Photovoltaic(power_rated_PV, fPV, IT, IS, investiment_cost_PV, om_cost_PV, replacement_cost_PV, salvage_cost_PV, lifetime_PV)\n",
+    "    battery = Battery(energy_initial, energy_max, energy_min, power_min, power_max, loss, investiment_cost_BT, om_cost_BT, replacement_cost_BT, salvage_cost_BT, lifetime_BT, lifetime_thrpt)\n",
+    "\n",
+    "    # Create microgrid\n",
+    "    microgrid = Microgrid(project, Pload, dieselgenerator, battery, [photovoltaic])\n",
+    "end\n",
+    "\n",
+    "function mg_create()\n",
+    "    # Importing load and solar data\n",
+    "    data = load_ts()\n",
+    "    mg_create(data)\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "98d9e64c-0c8b-4605-9029-ad3f7e22bb38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1.926 ms (415 allocations: 1.50 MiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@btime mg_create();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "84d6dd5f-7aba-4cdc-8fd1-31dceaeb4ab5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  13.103 μs (17 allocations: 274.38 KiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@btime mg_create(my_data);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "71cec732-6a2c-4c70-a043-95c42a776b45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const my_mg = mg_create();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b3eac1d-89b1-4e7f-beff-82ecb27e2df7",
+   "metadata": {},
+   "source": [
+    "## Microgrid simulation\n",
+    "\n",
+    "**7.7 ms** (7.7 MiB allocation) with an already created case description"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "5ab6846b-03dd-4cf5-af27-68b7458be12b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "mg_sim (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function mg_sim(mg)\n",
+    "    # Run simulation\n",
+    "    results = simulate(mg)\n",
+    "end\n",
+    "\n",
+    "function mg_sim()\n",
+    "    mg = mg_create()\n",
+    "    # Run simulation\n",
+    "    results = simulate(mg)\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "0042ddaf-db89-4e24-8ab3-ce994485a407",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  7.697 ms (413499 allocations: 7.72 MiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@btime mg_sim(my_mg);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ea3ae50-4251-4104-a0d8-0fa0daf35d1a",
+   "metadata": {},
+   "source": [
+    "### Timing of the 3 main steps of `simulate`\n",
+    "\n",
+    "1. operation: **5.1 ms** (5.6 MiB alloc)\n",
+    "2. aggregation: **2.3 ms** (2.1 MiB alloc)\n",
+    "3. economics: 15 µs, negligible, *but still 12 KiB alloc*\n",
+    "\n",
+    "for some reason, the sum (7.4 ms) is slighlty less than the global timing (7.7 ms). However, total allocation is consistent.\n",
+    "\n",
+    "Conclusion: `operation(mg)` and `aggregation(mg, opervarstraj)` should be the focus of the performance optimization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "66ac202c-2557-4bab-94c2-e62dbcf3ba35",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "simulate_time (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function simulate_time(mg)\n",
+    "    # Run the microgrid operation\n",
+    "    opervarstraj = @btime operation($mg)\n",
+    "\n",
+    "    # Aggregate the operation variables\n",
+    "    opervarsaggr = @btime aggregation($mg, $opervarstraj)\n",
+    "\n",
+    "    # Eval the microgrid costs\n",
+    "    costs = @btime economics($mg, $opervarsaggr)\n",
+    "\n",
+    "    return (opervarstraj = opervarstraj, opervarsaggr = opervarsaggr, costs = costs)\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "31b41847-a6d9-4271-9b12-0f4d5b703144",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  5.115 ms (285064 allocations: 5.62 MiB)\n",
+      "  2.267 ms (127928 allocations: 2.09 MiB)\n",
+      "  15.143 μs (507 allocations: 12.38 KiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "simulate_time(my_mg);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bbe0eb3-6995-4ddc-94c4-b8d837cc0f3e",
+   "metadata": {},
+   "source": [
+    "## Understanding type issues\n",
+    "\n",
+    "Observation: typing in `operation(mg)` is terrible since all variables are typed as `Any`. In particular, the call to the dispatch:\n",
+    "\n",
+    "```julia\n",
+    "outputs = dispatch(power_net_load_requested[i], Pbatt_cmax[i], Pbatt_dmax[i], mg.dieselgenerator.power_rated)\n",
+    "```\n",
+    "\n",
+    "becomes:\n",
+    "\n",
+    "```\n",
+    "│   %71  = Base.getindex(power_net_load_requested, i)::Any\n",
+    "│   %72  = Base.getindex(Pbatt_cmax, i)::Any\n",
+    "│   %73  = Base.getindex(Pbatt_dmax, i)::Any\n",
+    "│   %74  = Base.getproperty(mg, :dieselgenerator)::DieselGenerator\n",
+    "│   %75  = Base.getproperty(%74, :power_rated)::Any\n",
+    "│   %76  = Microgrids.dispatch(%71, %72, %73, %75)::NTuple{5, Any}\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "8a9d21df-f7eb-4c38-87e4-805e87f1d943",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MethodInstance for Microgrids.operation(::Microgrid)\n",
+      "  from operation(mg::Microgrid) in Microgrids at /home/pierre/Travail/31 Programmes divers/10 MicroGrid/Microgrid.jl/src/operation.jl:7\n",
+      "Arguments\n",
+      "  #self#\u001b[36m::Core.Const(Microgrids.operation)\u001b[39m\n",
+      "  mg\u001b[36m::Microgrid\u001b[39m\n",
+      "Locals\n",
+      "  @_3\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  #1\u001b[36m::Microgrids.var\"#1#2\"\u001b[39m\n",
+      "  opervarstraj\u001b[36m::OperVarsTraj\u001b[39m\n",
+      "  Pshed\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  Pcurt\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  Pbatt_cmax\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  Pbatt_dmax\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  Pbatt\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  Ebatt\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  Pgen\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  power_net_load\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  stepsnumber\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  power_net_load_requested\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  total_renewables_production\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  renewables_production\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  @_18\u001b[36m::Int64\u001b[39m\n",
+      "  i\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  Pb_emax\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  Pb_emin\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "Body\u001b[36m::OperVarsTraj\u001b[39m\n",
+      "\u001b[90m1 ─\u001b[39m        Core.NewvarNode(:(opervarstraj))\n",
+      "\u001b[90m│  \u001b[39m        (#1 = %new(Microgrids.:(var\"#1#2\")))\n",
+      "\u001b[90m│  \u001b[39m %3   = #1\u001b[36m::Core.Const(Microgrids.var\"#1#2\"())\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %4   = Base.getproperty(mg, :nondispatchables)\u001b[36m::Vector{NonDispatchables}\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %5   = Base.Generator(%3, %4)\u001b[36m::Base.Generator{Vector{NonDispatchables}, Microgrids.var\"#1#2\"}\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %6   = Microgrids.collect(%5)\u001b[91m\u001b[1m::Vector\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (renewables_production = Core._apply_iterate(Base.iterate, Microgrids.hcat, %6))\n",
+      "\u001b[90m│  \u001b[39m %8   = (:dims,)\u001b[36m::Core.Const((:dims,))\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %9   = Core.apply_type(Core.NamedTuple, %8)\u001b[36m::Core.Const(NamedTuple{(:dims,)})\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %10  = Core.tuple(2)\u001b[36m::Core.Const((2,))\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %11  = (%9)(%10)\u001b[36m::Core.Const((dims = 2,))\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %12  = Core.kwfunc(Microgrids.sum)\u001b[36m::Core.Const(Base.var\"#sum##kw\"())\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (total_renewables_production = (%12)(%11, Microgrids.sum, renewables_production))\n",
+      "\u001b[90m│  \u001b[39m %14  = Base.getproperty(mg, :power_load)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (power_net_load_requested = %14 - total_renewables_production)\n",
+      "\u001b[90m│  \u001b[39m %16  = Base.getproperty(mg, :power_load)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (stepsnumber = Microgrids.length(%16))\n",
+      "\u001b[90m│  \u001b[39m        (power_net_load = Microgrids.zeros(Microgrids.Real, stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pgen = Microgrids.zeros(Microgrids.Real, stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m %20  = (stepsnumber + 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (Ebatt = Microgrids.zeros(Microgrids.Real, %20))\n",
+      "\u001b[90m│  \u001b[39m %22  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %23  = Base.getproperty(%22, :energy_initial)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Ebatt, %23, 1)\n",
+      "\u001b[90m│  \u001b[39m        (Pbatt = Microgrids.zeros(Microgrids.Real, stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pbatt_dmax = Microgrids.zeros(Microgrids.Real, stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pbatt_cmax = Microgrids.zeros(Microgrids.Real, stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pcurt = Microgrids.zeros(Microgrids.Real, stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pshed = Microgrids.zeros(Microgrids.Real, stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m %30  = (1:stepsnumber)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_3 = Base.iterate(%30))\n",
+      "\u001b[90m│  \u001b[39m %32  = (@_3 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %33  = Base.not_int(%32)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m        goto #6 if not %33\n",
+      "\u001b[90m2 ┄\u001b[39m %35  = @_3\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (i = Core.getfield(%35, 1))\n",
+      "\u001b[90m│  \u001b[39m %37  = Core.getfield(%35, 2)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %38  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %39  = Base.getproperty(%38, :energy_max)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %40  = Base.getindex(Ebatt, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %41  = (%39 - %40)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %42  = -%41\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %43  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %44  = Base.getproperty(%43, :loss)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %45  = (1 - %44)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %46  = Base.getproperty(mg, :project)\u001b[36m::Project\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %47  = Base.getproperty(%46, :timestep)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %48  = (%45 * %47)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (Pb_emin = %42 / %48)\n",
+      "\u001b[90m│  \u001b[39m %50  = Base.getindex(Ebatt, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %51  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %52  = Base.getproperty(%51, :energy_min)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %53  = (%50 - %52)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %54  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %55  = Base.getproperty(%54, :loss)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %56  = (1 + %55)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %57  = Base.getproperty(mg, :project)\u001b[36m::Project\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %58  = Base.getproperty(%57, :timestep)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %59  = (%56 * %58)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (Pb_emax = %53 / %59)\n",
+      "\u001b[90m│  \u001b[39m %61  = Pb_emax\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %62  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %63  = Base.getproperty(%62, :power_max)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %64  = Microgrids.min(%61, %63)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pbatt_dmax, %64, i)\n",
+      "\u001b[90m│  \u001b[39m %66  = Pb_emin\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %67  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %68  = Base.getproperty(%67, :power_min)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %69  = Microgrids.max(%66, %68)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pbatt_cmax, %69, i)\n",
+      "\u001b[90m│  \u001b[39m %71  = Base.getindex(power_net_load_requested, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %72  = Base.getindex(Pbatt_cmax, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %73  = Base.getindex(Pbatt_dmax, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %74  = Base.getproperty(mg, :dieselgenerator)\u001b[36m::DieselGenerator\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %75  = Base.getproperty(%74, :power_rated)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %76  = Microgrids.dispatch(%71, %72, %73, %75)\u001b[91m\u001b[1m::NTuple{5, Any}\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %77  = Base.indexed_iterate(%76, 1)\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(2)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %78  = Core.getfield(%77, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_18 = Core.getfield(%77, 2))\n",
+      "\u001b[90m│  \u001b[39m %80  = Base.indexed_iterate(%76, 2, @_18::Core.Const(2))\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(3)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %81  = Core.getfield(%80, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_18 = Core.getfield(%80, 2))\n",
+      "\u001b[90m│  \u001b[39m %83  = Base.indexed_iterate(%76, 3, @_18::Core.Const(3))\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(4)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %84  = Core.getfield(%83, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_18 = Core.getfield(%83, 2))\n",
+      "\u001b[90m│  \u001b[39m %86  = Base.indexed_iterate(%76, 4, @_18::Core.Const(4))\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(5)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %87  = Core.getfield(%86, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_18 = Core.getfield(%86, 2))\n",
+      "\u001b[90m│  \u001b[39m %89  = Base.indexed_iterate(%76, 5, @_18::Core.Const(5))\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(6)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %90  = Core.getfield(%89, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(power_net_load, %78, i)\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pgen, %81, i)\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pbatt, %84, i)\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pcurt, %87, i)\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pshed, %90, i)\n",
+      "\u001b[90m│  \u001b[39m %96  = (i < stepsnumber)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m        goto #4 if not %96\n",
+      "\u001b[90m3 ─\u001b[39m %98  = Base.getindex(Ebatt, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %99  = Base.getindex(Pbatt, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %100 = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %101 = Base.getproperty(%100, :loss)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %102 = Base.getindex(Pbatt, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %103 = Microgrids.abs(%102)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %104 = (%101 * %103)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %105 = (%99 + %104)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %106 = Base.getproperty(mg, :project)\u001b[36m::Project\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %107 = Base.getproperty(%106, :timestep)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %108 = (%105 * %107)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %109 = (%98 - %108)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %110 = Ebatt\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %111 = (i + 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m        Base.setindex!(%110, %109, %111)\n",
+      "\u001b[90m4 ┄\u001b[39m        (@_3 = Base.iterate(%30, %37))\n",
+      "\u001b[90m│  \u001b[39m %114 = (@_3 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %115 = Base.not_int(%114)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m        goto #6 if not %115\n",
+      "\u001b[90m5 ─\u001b[39m        goto #2\n",
+      "\u001b[90m6 ┄\u001b[39m        (opervarstraj = Microgrids.OperVarsTraj(power_net_load, Pshed, Pgen, Ebatt, Pbatt, Pbatt_dmax, Pbatt_cmax, Pcurt))\n",
+      "\u001b[90m└──\u001b[39m        return opervarstraj\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "@code_warntype operation(my_mg);"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.7.3",
+   "language": "julia",
+   "name": "julia-1.7"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/perf/Microgrids.jl_performance_analysis.ipynb
+++ b/perf/Microgrids.jl_performance_analysis.ipynb
@@ -16,10 +16,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "id": "91688f98-2f64-4936-a7e2-aa8ae544ebd1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "┌ Info: Precompiling Microgrids [bd581358-d3fa-499e-a26e-e70307242c03]\n",
+      "└ @ Base loading.jl:1423\n"
+     ]
+    }
+   ],
    "source": [
     "using Microgrids\n",
     "using BenchmarkTools\n",
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "id": "05944285-4478-4523-868c-29539cc8c2ce",
    "metadata": {},
    "outputs": [
@@ -38,7 +47,7 @@
        "load_ts"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -63,23 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "08a81513-03e1-4af4-838b-4f4fc02605bd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "function J(x, args)\n",
-    "end\n",
-    "\n",
-    "for i \n",
-    "    \n",
-    "    f(x, grad) = J(x,r[i])\n",
-    "    optimize(f)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "id": "6ba8de07-86cf-43f1-acb4-b00ab26a4355",
    "metadata": {},
    "outputs": [
@@ -97,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "id": "916c7f55-5ed7-4518-bda3-3920339c1f6d",
    "metadata": {},
    "outputs": [],
@@ -107,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "id": "efff55db-2838-4ce6-9314-26b0f1a99d2b",
    "metadata": {},
    "outputs": [
@@ -117,7 +110,7 @@
        "mg_create (generic function with 2 methods)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -138,7 +131,7 @@
     "    power_rated_PV = 4106.82251423571\n",
     "    fPV = 1.\n",
     "    IT = data.\"Ppv1k\"[1:ntimestep] ./ 1000\n",
-    "    IS = ones(ntimestep)\n",
+    "    IS = 1.\n",
     "    investiment_cost_PV = 1200.\n",
     "    om_cost_PV = 20.  \n",
     "    replacement_cost_PV = 1200.\n",
@@ -188,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "id": "98d9e64c-0c8b-4605-9029-ad3f7e22bb38",
    "metadata": {},
    "outputs": [
@@ -196,7 +189,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  1.926 ms (415 allocations: 1.50 MiB)\n"
+      "  1.736 ms (415 allocations: 1.44 MiB)\n"
      ]
     }
    ],
@@ -206,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "id": "84d6dd5f-7aba-4cdc-8fd1-31dceaeb4ab5",
    "metadata": {},
    "outputs": [
@@ -214,7 +207,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  13.103 μs (17 allocations: 274.38 KiB)\n"
+      "  9.748 μs (17 allocations: 206.19 KiB)\n"
      ]
     }
    ],
@@ -224,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 8,
    "id": "71cec732-6a2c-4c70-a043-95c42a776b45",
    "metadata": {},
    "outputs": [],
@@ -244,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 9,
    "id": "5ab6846b-03dd-4cf5-af27-68b7458be12b",
    "metadata": {},
    "outputs": [
@@ -254,7 +247,7 @@
        "mg_sim (generic function with 2 methods)"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -274,6 +267,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
+   "id": "fb65aa16-deac-4bd5-bddb-84a3766a4b12",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4.628 ms (325736 allocations: 6.24 MiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@btime mg_sim(my_mg);"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 24,
    "id": "0042ddaf-db89-4e24-8ab3-ce994485a407",
    "metadata": {},
@@ -287,7 +298,7 @@
     }
    ],
    "source": [
-    "@btime mg_sim(my_mg);"
+    "@btime mg_sim(my_mg); # code with Any type"
    ]
   },
   {
@@ -308,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 11,
    "id": "66ac202c-2557-4bab-94c2-e62dbcf3ba35",
    "metadata": {},
    "outputs": [
@@ -318,7 +329,7 @@
        "simulate_time (generic function with 1 method)"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -340,6 +351,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
+   "id": "d7916b2e-55e7-4a76-964c-99ae56747f6c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2.261 ms (138368 allocations: 3.25 MiB)\n",
+      "  1.864 ms (187241 allocations: 2.99 MiB)\n",
+      "  7.275 μs (127 allocations: 5.22 KiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "simulate_time(my_mg);"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 36,
    "id": "31b41847-a6d9-4271-9b12-0f4d5b703144",
    "metadata": {},
@@ -355,7 +386,7 @@
     }
    ],
    "source": [
-    "simulate_time(my_mg);"
+    "simulate_time(my_mg); # code with Any type"
    ]
   },
   {
@@ -381,6 +412,172 @@
     "│   %75  = Base.getproperty(%74, :power_rated)::Any\n",
     "│   %76  = Microgrids.dispatch(%71, %72, %73, %75)::NTuple{5, Any}\n",
     "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2f2e484a-ec77-4518-9297-ba0b6dec7936",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MethodInstance for Microgrids.operation(::Microgrid)\n",
+      "  from operation(mg::Microgrid) in Microgrids at /home/pierre/Travail/31 Programmes divers/10 MicroGrid/Microgrid.jl/src/operation.jl:7\n",
+      "Arguments\n",
+      "  #self#\u001b[36m::Core.Const(Microgrids.operation)\u001b[39m\n",
+      "  mg\u001b[36m::Microgrid\u001b[39m\n",
+      "Locals\n",
+      "  @_3\u001b[33m\u001b[1m::Union{Nothing, Tuple{Int64, Int64}}\u001b[22m\u001b[39m\n",
+      "  #1\u001b[36m::Microgrids.var\"#1#2\"\u001b[39m\n",
+      "  opervarstraj\u001b[36m::OperVarsTraj\u001b[39m\n",
+      "  Pshed\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "  Pcurt\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "  Pbatt_cmax\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "  Pbatt_dmax\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "  Pbatt\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "  Ebatt\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "  Pgen\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "  power_net_load\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "  T\u001b[36m::Type{Float64}\u001b[39m\n",
+      "  stepsnumber\u001b[36m::Int64\u001b[39m\n",
+      "  power_net_load_requested\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  total_renewables_production\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  renewables_production\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "  @_19\u001b[36m::Int64\u001b[39m\n",
+      "  i\u001b[36m::Int64\u001b[39m\n",
+      "  Pb_emax\u001b[36m::Float64\u001b[39m\n",
+      "  Pb_emin\u001b[36m::Float64\u001b[39m\n",
+      "Body\u001b[36m::OperVarsTraj\u001b[39m\n",
+      "\u001b[90m1 ─\u001b[39m        Core.NewvarNode(:(opervarstraj))\n",
+      "\u001b[90m│  \u001b[39m        (#1 = %new(Microgrids.:(var\"#1#2\")))\n",
+      "\u001b[90m│  \u001b[39m %3   = #1\u001b[36m::Core.Const(Microgrids.var\"#1#2\"())\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %4   = Base.getproperty(mg, :nondispatchables)\u001b[36m::Vector{NonDispatchables}\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %5   = Base.Generator(%3, %4)\u001b[36m::Base.Generator{Vector{NonDispatchables}, Microgrids.var\"#1#2\"}\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %6   = Microgrids.collect(%5)\u001b[91m\u001b[1m::Union{Vector{Vector{Float64}}, Vector{Vector}, Vector{Vector{Real}}}\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (renewables_production = Core._apply_iterate(Base.iterate, Microgrids.hcat, %6))\n",
+      "\u001b[90m│  \u001b[39m %8   = (:dims,)\u001b[36m::Core.Const((:dims,))\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %9   = Core.apply_type(Core.NamedTuple, %8)\u001b[36m::Core.Const(NamedTuple{(:dims,)})\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %10  = Core.tuple(2)\u001b[36m::Core.Const((2,))\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %11  = (%9)(%10)\u001b[36m::Core.Const((dims = 2,))\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %12  = Core.kwfunc(Microgrids.sum)\u001b[36m::Core.Const(Base.var\"#sum##kw\"())\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (total_renewables_production = (%12)(%11, Microgrids.sum, renewables_production))\n",
+      "\u001b[90m│  \u001b[39m %14  = Base.getproperty(mg, :power_load)\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (power_net_load_requested = %14 - total_renewables_production)\n",
+      "\u001b[90m│  \u001b[39m %16  = Base.getproperty(mg, :power_load)\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (stepsnumber = Microgrids.length(%16))\n",
+      "\u001b[90m│  \u001b[39m        (T = Microgrids.Float64)\n",
+      "\u001b[90m│  \u001b[39m        (power_net_load = Microgrids.zeros(T::Core.Const(Float64), stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pgen = Microgrids.zeros(T::Core.Const(Float64), stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m %21  = T\u001b[36m::Core.Const(Float64)\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %22  = (stepsnumber + 1)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (Ebatt = Microgrids.zeros(%21, %22))\n",
+      "\u001b[90m│  \u001b[39m %24  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %25  = Base.getproperty(%24, :energy_initial)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Ebatt, %25, 1)\n",
+      "\u001b[90m│  \u001b[39m        (Pbatt = Microgrids.zeros(T::Core.Const(Float64), stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pbatt_dmax = Microgrids.zeros(T::Core.Const(Float64), stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pbatt_cmax = Microgrids.zeros(T::Core.Const(Float64), stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pcurt = Microgrids.zeros(T::Core.Const(Float64), stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m        (Pshed = Microgrids.zeros(T::Core.Const(Float64), stepsnumber))\n",
+      "\u001b[90m│  \u001b[39m %32  = (1:stepsnumber)\u001b[36m::Core.PartialStruct(UnitRange{Int64}, Any[Core.Const(1), Int64])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_3 = Base.iterate(%32))\n",
+      "\u001b[90m│  \u001b[39m %34  = (@_3 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %35  = Base.not_int(%34)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m        goto #6 if not %35\n",
+      "\u001b[90m2 ┄\u001b[39m %37  = @_3\u001b[36m::Tuple{Int64, Int64}\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (i = Core.getfield(%37, 1))\n",
+      "\u001b[90m│  \u001b[39m %39  = Core.getfield(%37, 2)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %40  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %41  = Base.getproperty(%40, :energy_max)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %42  = Base.getindex(Ebatt, i)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %43  = (%41 - %42)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %44  = -%43\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %45  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %46  = Base.getproperty(%45, :loss)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %47  = (1 - %46)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %48  = Base.getproperty(mg, :project)\u001b[36m::Project\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %49  = Base.getproperty(%48, :timestep)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %50  = (%47 * %49)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (Pb_emin = %44 / %50)\n",
+      "\u001b[90m│  \u001b[39m %52  = Base.getindex(Ebatt, i)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %53  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %54  = Base.getproperty(%53, :energy_min)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %55  = (%52 - %54)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %56  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %57  = Base.getproperty(%56, :loss)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %58  = (1 + %57)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %59  = Base.getproperty(mg, :project)\u001b[36m::Project\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %60  = Base.getproperty(%59, :timestep)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %61  = (%58 * %60)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (Pb_emax = %55 / %61)\n",
+      "\u001b[90m│  \u001b[39m %63  = Pb_emax\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %64  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %65  = Base.getproperty(%64, :power_max)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %66  = Microgrids.min(%63, %65)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pbatt_dmax, %66, i)\n",
+      "\u001b[90m│  \u001b[39m %68  = Pb_emin\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %69  = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %70  = Base.getproperty(%69, :power_min)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %71  = Microgrids.max(%68, %70)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pbatt_cmax, %71, i)\n",
+      "\u001b[90m│  \u001b[39m %73  = Base.getindex(power_net_load_requested, i)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %74  = Base.getindex(Pbatt_cmax, i)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %75  = Base.getindex(Pbatt_dmax, i)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %76  = Base.getproperty(mg, :dieselgenerator)\u001b[36m::DieselGenerator\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %77  = Base.getproperty(%76, :power_rated)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %78  = Microgrids.dispatch(%73, %74, %75, %77)\u001b[91m\u001b[1m::NTuple{5, Any}\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %79  = Base.indexed_iterate(%78, 1)\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(2)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %80  = Core.getfield(%79, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_19 = Core.getfield(%79, 2))\n",
+      "\u001b[90m│  \u001b[39m %82  = Base.indexed_iterate(%78, 2, @_19::Core.Const(2))\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(3)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %83  = Core.getfield(%82, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_19 = Core.getfield(%82, 2))\n",
+      "\u001b[90m│  \u001b[39m %85  = Base.indexed_iterate(%78, 3, @_19::Core.Const(3))\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(4)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %86  = Core.getfield(%85, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_19 = Core.getfield(%85, 2))\n",
+      "\u001b[90m│  \u001b[39m %88  = Base.indexed_iterate(%78, 4, @_19::Core.Const(4))\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(5)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %89  = Core.getfield(%88, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        (@_19 = Core.getfield(%88, 2))\n",
+      "\u001b[90m│  \u001b[39m %91  = Base.indexed_iterate(%78, 5, @_19::Core.Const(5))\u001b[36m::Core.PartialStruct(Tuple{Any, Int64}, Any[Any, Core.Const(6)])\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %92  = Core.getfield(%91, 1)\u001b[91m\u001b[1m::Any\u001b[22m\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(power_net_load, %80, i)\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pgen, %83, i)\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pbatt, %86, i)\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pcurt, %89, i)\n",
+      "\u001b[90m│  \u001b[39m        Base.setindex!(Pshed, %92, i)\n",
+      "\u001b[90m│  \u001b[39m %98  = (i < stepsnumber)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m        goto #4 if not %98\n",
+      "\u001b[90m3 ─\u001b[39m %100 = Base.getindex(Ebatt, i)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %101 = Base.getindex(Pbatt, i)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %102 = Base.getproperty(mg, :battery)\u001b[36m::Battery\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %103 = Base.getproperty(%102, :loss)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %104 = Base.getindex(Pbatt, i)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %105 = Microgrids.abs(%104)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %106 = (%103 * %105)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %107 = (%101 + %106)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %108 = Base.getproperty(mg, :project)\u001b[36m::Project\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %109 = Base.getproperty(%108, :timestep)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %110 = (%107 * %109)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %111 = (%100 - %110)\u001b[36m::Float64\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %112 = Ebatt\u001b[36m::Vector{Float64}\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %113 = (i + 1)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m        Base.setindex!(%112, %111, %113)\n",
+      "\u001b[90m4 ┄\u001b[39m        (@_3 = Base.iterate(%32, %39))\n",
+      "\u001b[90m│  \u001b[39m %116 = (@_3 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %117 = Base.not_int(%116)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m        goto #6 if not %117\n",
+      "\u001b[90m5 ─\u001b[39m        goto #2\n",
+      "\u001b[90m6 ┄\u001b[39m        (opervarstraj = Microgrids.OperVarsTraj(power_net_load, Pshed, Pgen, Ebatt, Pbatt, Pbatt_dmax, Pbatt_cmax, Pcurt))\n",
+      "\u001b[90m└──\u001b[39m        return opervarstraj\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "@code_warntype operation(my_mg);"
    ]
   },
   {
@@ -543,7 +740,7 @@
     }
    ],
    "source": [
-    "@code_warntype operation(my_mg);"
+    "@code_warntype operation(my_mg); # code with Any type"
    ]
   }
  ],

--- a/perf/MicrogridsBenchmark.jl
+++ b/perf/MicrogridsBenchmark.jl
@@ -1,0 +1,81 @@
+using Microgrids
+using BenchmarkTools
+using CSV, DataFrames
+
+
+function mg_create()
+    data = DataFrame(CSV.File("$(@__DIR__)/../examples/microgrid_with_PV_BT_DG/data/Ouessant_data_2016.csv"))
+    # Simulation steps
+    ntimestep = length(data.Load)
+
+    # Components parameters
+    # Project
+    lifetime = 25
+    discount_rate = 0.05
+    timestep = 1
+    # Load
+    Pload = data."Load"[1:ntimestep]
+    # Photovoltaic
+    power_rated_PV = 4106.82251423571
+    fPV = 1.
+    IT = data."Ppv1k"[1:ntimestep] ./ 1000
+    IS = 1.
+    investiment_cost_PV = 1200.
+    om_cost_PV = 20.  
+    replacement_cost_PV = 1200.
+    salvage_cost_PV = 1200.
+    lifetime_PV = 25
+    # Battery
+    energy_initial = 0.
+    energy_max = 6839.87944197573
+    energy_min = 0
+    power_min = -1.114*energy_max
+    power_max = 1.002*energy_max
+    loss = 0.05
+    investiment_cost_BT = 350.
+    om_cost_BT = 10.
+    replacement_cost_BT = 350.
+    salvage_cost_BT = 350.
+    lifetime_BT = 15
+    lifetime_thrpt = 3000
+    # Diesel generator
+    power_rated_DG = 1800.
+    min_load_ratio = 0
+    F0 = 0.0
+    F1 = 0.240
+    fuel_cost = 1.
+    investiment_cost_DG = 400.
+    om_cost_DG = 0.02
+    replacement_cost_DG = 400.
+    salvage_cost_DG = 400.
+    lifetime_DG = 15000
+
+    # Create microgrid components
+    project = Project(lifetime, discount_rate, timestep)
+    dieselgenerator = DieselGenerator(power_rated_DG, min_load_ratio, F0, F1, fuel_cost, investiment_cost_DG, om_cost_DG, replacement_cost_DG, salvage_cost_DG, lifetime_DG)
+    photovoltaic = Photovoltaic(power_rated_PV, fPV, IT, IS, investiment_cost_PV, om_cost_PV, replacement_cost_PV, salvage_cost_PV, lifetime_PV)
+    battery = Battery(energy_initial, energy_max, energy_min, power_min, power_max, loss, investiment_cost_BT, om_cost_BT, replacement_cost_BT, salvage_cost_BT, lifetime_BT, lifetime_thrpt)
+
+    # Create microgrid
+    microgrid = Microgrid(project, Pload, dieselgenerator, battery, [photovoltaic])
+end
+
+mg = mg_create();
+print("timing of simulate(mg):")
+@btime results = simulate($mg)
+
+function simulate_time(mg)
+    # Run the microgrid operation
+    opervarstraj = @btime operation($mg)
+
+    # Aggregate the operation variables
+    opervarsaggr = @btime aggregation($mg, $opervarstraj)
+
+    # Eval the microgrid costs
+    costs = @btime economics($mg, $opervarsaggr)
+
+    return (opervarstraj = opervarstraj, opervarsaggr = opervarsaggr, costs = costs)
+end
+
+print("\ndetailed timing of simulate(mg):\n")
+simulate_time(mg);

--- a/perf/MicrogridsBenchmark_output.md
+++ b/perf/MicrogridsBenchmark_output.md
@@ -1,0 +1,12 @@
+# Run of MicrogridsBenchmark.jl on Dell notebook (i7-1165G7)
+
+2022-06-21 changes: 
+* typing of sum(renewables_production), which fixes the issue with collect(production())
+* typing of OperVarsTraj
+
+timing of simulate(mg):  206.804 μs (164 allocations: 759.11 KiB)
+
+detailed timing of simulate(mg):
+  156.387 μs (24 allocations: 753.53 KiB)
+  40.100 μs (9 allocations: 144 bytes)
+  7.843 μs (131 allocations: 5.44 KiB)

--- a/src/components.jl
+++ b/src/components.jl
@@ -5,63 +5,63 @@ abstract type NonDispatchables end
 "Microgrid project information."
 struct Project
     "lifetime (years)"
-    lifetime
+    lifetime::Int
     "discount rate ∈ [0,1]"
-    discount_rate
+    discount_rate::Float64
     "time step (h)"
-    timestep
+    timestep::Float64
     # TODO dispatch_type?
 end
 
 "Diesel generator parameters."
 struct DieselGenerator
     "Rated power (kW)"
-    power_rated   # decision variable
+    power_rated::Float64   # decision variable
     "Minimum load ratio ∈ [0,1]"
-    minimum_load_ratio  # ever it is on, it will work at least `min_load_ratio` of the power_max
+    minimum_load_ratio::Float64  # ever it is on, it will work at least `min_load_ratio` of the power_max
     # min_production = min_load_ratio * power_max   # TODO - maybe it's a internal variable
     "Fuel curve intercept coefficient (L/(h × kW))"
-    F0
+    F0::Float64
     "Fuel curve slope (L/(h × kW))"
-    F1
+    F1::Float64
     
     # economics
     "Fuel cost (currency unit/L)"
-    fuel_cost
+    fuel_cost::Float64
     "Investiment cost (currency unit/kW)"
-    investment_cost
+    investment_cost::Float64
     "Operation and maintenance cost (currency unit/(kW.h))"
-    om_cost
+    om_cost::Float64
     "Replacement cost (currency unit/kW)"
-    replacement_cost
+    replacement_cost::Float64
     "Salvage cost (currency unit/kW)"
-    salvage_cost
+    salvage_cost::Float64
     "Lifetime (h)"
-    lifetime
+    lifetime::Float64
 end
 
 "Photovoltaic parameters."
 struct Photovoltaic <: NonDispatchables
     "Rated power (kW)"
-    power_rated   # decision variable
+    power_rated::Float64   # decision variable
     "Derating factor ∈ [0,1]"
-    derating_factor
+    derating_factor::Float64
     "Incident global solar radiation (kW/m²)"
-    IT
+    IT::Vector{Float64}
     "Standard amount of global solar radiation (kW/m²)"
-    IS
+    IS::Float64
 
     # economics
     "Investiment cost (currency unit/kW)"
-    investment_cost
+    investment_cost::Float64
     "Operation and maintenance cost (currency unit/kW)"
-    om_cost
+    om_cost::Float64
     "Replacement cost (currency unit/kW)"
-    replacement_cost
+    replacement_cost::Float64
     "Salvage cost (currency unit/kW)"
-    salvage_cost
+    salvage_cost::Float64
     "Lifetime (years)"
-    lifetime
+    lifetime::Float64
 
     # Photovoltaic(fPV, IT, IS, Y_PV) = new(fPV, IT, IS, Y_PV)
 end
@@ -69,37 +69,37 @@ end
 "Photovoltaic parameters with inverter issues (AC DC)"
 struct PVInverter <: NonDispatchables
     "Rated power in AC (kW)"
-    power_rated
+    power_rated::Float64
     "Inverter loading ratio = PAC_rated/PDC_rated"
-    ILR
+    ILR::Float64
     "Derating factor ∈ [0,1]"
-    derating_factor
+    derating_factor::Float64
     "global solar irradiance incident on the PV array (kW/m²)"
-    irradiance
+    irradiance::Vector{Float64}
 
     # economics
     #AC (inverter)
     "Investiment cost of inverter (currency unit/kW)"
-    investment_cost_ac
+    investment_cost_ac::Float64
     "Operation and maintenance cost of inverter (currency unit/kW)"
-    om_cost_ac
+    om_cost_ac::Float64
     "Replacement cost of inverter (currency unit/kW)"
-    replacement_cost_ac
+    replacement_cost_ac::Float64
     "Salvage cost of inverter (currency unit/kW)"
-    salvage_cost_ac
+    salvage_cost_ac::Float64
     "Lifetime of inverter (years)"
-    lifetime_ac
+    lifetime_ac::Float64
     #DC (panels)
     "Investiment cost of pannels (currency unit/kW)"
-    investment_cost_dc
+    investment_cost_dc::Float64
     "Operation and maintenance cost of pannels (currency unit/kW)"
-    om_cost_dc
+    om_cost_dc::Float64
     "Replacement cost of pannels (currency unit/kW)"
-    replacement_cost_dc
+    replacement_cost_dc::Float64
     "Salvage cost of pannels (currency unit/kW)"
-    salvage_cost_dc
+    salvage_cost_dc::Float64
     "Lifetime of pannels (years)"
-    lifetime_dc
+    lifetime_dc::Float64
     # Photovoltaic(fPV, IT, IS, Y_PV) = new(fPV, IT, IS, Y_PV)
 
 end
@@ -107,65 +107,65 @@ end
 "Wind turbine parameters."
 struct WindPower <: NonDispatchables
     "Rated power (kW)"
-    power_rated
+    power_rated::Float64
     "Cut-in speed (m/s)"
-    U_cut_in
+    U_cut_in::Float64
     "Cut-out speed (m/s)"
-    U_cut_out
+    U_cut_out::Float64
     "Rated speed (m/s)"
-    U_rated
+    U_rated::Float64
     "Wind speed at the measurement height (m/s)"
-    Uanem
+    Uanem::Vector{Float64}
     "Hub height (m)"
-    zhub
+    zhub::Float64
     "Measurement height (m)"
-    zanem
+    zanem::Float64
     "Roughness length (m)"
-    z0
+    z0::Float64
     # TODO rho
     # TODO rho0
 
     # economics
     "Investiment cost (currency unit/kW)"
-    investment_cost
+    investment_cost::Float64
     "Operation and maintenance cost (currency unit/kW)"
-    om_cost
+    om_cost::Float64
     "Replacement cost (currency unit/kW)"
-    replacement_cost
+    replacement_cost::Float64
     "Salvage cost (currency unit/kW)"
-    salvage_cost
+    salvage_cost::Float64
     "Lifetime (years)"
-    lifetime
+    lifetime::Float64
 end
 
 "Battery parameters."
 struct Battery
     "Initial energy (kWh)"
-    energy_initial
+    energy_initial::Float64
     "Rated energy capacity (kWh)"
-    energy_max    # Eb_max
+    energy_max::Float64    # Eb_max
     "Minimum energy level (kWh)"
-    energy_min    # Eb_min  TODO - it could be the minimum state of charge too
+    energy_min::Float64    # Eb_min  TODO - it could be the minimum state of charge too
     "Maximum charge power ∈ ``\\mathbf{R}^-`` (kW)"
-    power_min     # Pb_min - charge (negative)
+    power_min::Float64     # Pb_min - charge (negative)
     "Maximum discharge power (kW)"
-    power_max     # Pb_max - discharge
+    power_max::Float64     # Pb_max - discharge
     "Linear loss factor ∈ [0,1]"
-    loss
+    loss::Float64
 
     # economics
     "Investiment cost (currency unit/kWh)"
-    investment_cost
+    investment_cost::Float64
     "Operation and maintenance cost (currency unit/kWh)"
-    om_cost
+    om_cost::Float64
     "Replacement cost (currency unit/kWh)"
-    replacement_cost
+    replacement_cost::Float64
     "Salvage cost (currency unit/kWh)"
-    salvage_cost
+    salvage_cost::Float64
     "Lifetime (years)"
-    lifetime
+    lifetime::Float64
     "Maximum number of cycles"
-    lifetime_throughput  # max throughput
+    lifetime_throughput::Float64  # max throughput
 end
 
 # Operation variables - Trajectory
@@ -225,7 +225,7 @@ end
 # Microgrid
 struct Microgrid
     project::Project
-    power_load
+    power_load::Vector{Float64}
     dieselgenerator::DieselGenerator
     # photovoltaic::Photovoltaic
     # windpower::WindPower

--- a/src/components.jl
+++ b/src/components.jl
@@ -169,29 +169,29 @@ struct Battery
 end
 
 # Operation variables - Trajectory
-struct OperVarsTraj
+struct OperVarsTraj{T<:Real}
     # load
     #= "Net load at each time instant after using the renewables power (kW)"
     Pnl_req =#
     "Net load at each time instant after dispatch (kW)"
-    power_net_load
+    power_net_load::Vector{T}
     "Unmet load/Load shedding power at each time instant (kW)"
-    power_shedding
+    power_shedding::Vector{T}
     # diesel generator
     "Diesel generator power at each time instant (kW)"
-    Pgen
+    Pgen::Vector{T}
     # battery
     "Battery energy at each time instant (kWh)"
-    Ebatt
+    Ebatt::Vector{T}
     "Battery power at each time instant (kW)"
-    Pbatt
+    Pbatt::Vector{T}
     "Maximum battery discharge power at time t (kW)"
-    Pbatt_dmax
+    Pbatt_dmax::Vector{T}
     "Maximum battery charge power at time t (kW)"
-    Pbatt_cmax
+    Pbatt_cmax::Vector{T}
     # renewables sources
     "Renewables curtailment power at each time instant (kW)"
-    power_curtailment
+    power_curtailment::Vector{T}
 end
 
 # Operation variables - Aggregation
@@ -230,5 +230,5 @@ struct Microgrid
     # photovoltaic::Photovoltaic
     # windpower::WindPower
     battery::Battery
-    nondispatchables::Vector{NonDispatchables}
+    nondispatchables #::Vector{NonDispatchables}
 end

--- a/src/operation.jl
+++ b/src/operation.jl
@@ -19,15 +19,16 @@ function operation(mg::Microgrid)
 
     # variables initialization
     stepsnumber = length(mg.power_load)
-    power_net_load = zeros(Real,stepsnumber)   # TODO - change Real to typeof(...)
-    Pgen = zeros(Real,stepsnumber)
-    Ebatt = zeros(Real,stepsnumber+1)
+    T = Float64 # TODO: use some typeof call instead. But typeof which variable...?
+    power_net_load = zeros(T,stepsnumber)
+    Pgen = zeros(T,stepsnumber)
+    Ebatt = zeros(T,stepsnumber+1)
     Ebatt[1] = mg.battery.energy_initial
-    Pbatt = zeros(Real,stepsnumber)
-    Pbatt_dmax = zeros(Real,stepsnumber)
-    Pbatt_cmax = zeros(Real,stepsnumber)
-    Pcurt = zeros(Real,stepsnumber)
-    Pshed = zeros(Real,stepsnumber)
+    Pbatt = zeros(T,stepsnumber)
+    Pbatt_dmax = zeros(T,stepsnumber)
+    Pbatt_cmax = zeros(T,stepsnumber)
+    Pcurt = zeros(T,stepsnumber)
+    Pshed = zeros(T,stepsnumber)
 
     for i=1:stepsnumber
         # battery limits

--- a/src/operation.jl
+++ b/src/operation.jl
@@ -7,14 +7,14 @@ hourly operation variables `OperVarsTraj`.
 function operation(mg::Microgrid)
     # photovoltaic production over one year
     # photovoltaic_production = production(mg.photovoltaic)
-    renewables_production = hcat(collect(production(nd) for nd in mg.nondispatchables)...)
+    renewables_production = collect(production(nd) for nd in mg.nondispatchables)
 
     # wind turbine production over one year
     # windpower_production = production(mg.windpower)
 
     # power balance before battery+generator
     # renewable_production = photovoltaic_production + windpower_production
-    total_renewables_production = sum(renewables_production; dims=2)
+    total_renewables_production = sum(renewables_production)::Vector{Float64}
     power_net_load_requested = mg.power_load - total_renewables_production
 
     # variables initialization

--- a/src/production.jl
+++ b/src/production.jl
@@ -16,7 +16,8 @@ Return the power output of the `photovoltaic` source.
 """
 function production(photovoltaic::PVInverter)
     PDC_rated=photovoltaic.ILR*photovoltaic.power_rated
-    PAC=zeros(Real,length(photovoltaic.irradiance))
+    T = typeof(PDC_rated)
+    PAC=zeros(T, length(photovoltaic.irradiance))
     for i=1:length(photovoltaic.irradiance)
         PDC_i=photovoltaic.irradiance[i]*PDC_rated*photovoltaic.derating_factor
         PAC[i]=min(PDC_i,photovoltaic.power_rated)


### PR DESCRIPTION
@NielsThobie, these are a set of typing changes which bring a x35 speed up for `simulate(mg)` on my machine (from 7.7 ms down to 206 µs). You can run `perf/MicrogridsBenchmark.jl` to check timing on your machine.

Only downside of these changes is that this breaks @evelisea's programs which use `ForwardDiff` (which generates numbers with more complicated types). Because of this, in my repo it's not in the main branch, but in a dedicated `Float64` branch.

Since you are using gradient-free optimization, this should not impact your work, except in a beneficial manner... ;-)